### PR TITLE
attestation security protocol fix

### DIFF
--- a/dht_lookup.go
+++ b/dht_lookup.go
@@ -181,7 +181,7 @@ func (dht *DHT) queryNodesParallel(nodes []*System, targetID uuid.UUID) []queryR
 				return
 			}
 
-			closestNodes, err := dht.FindNodeDirect(sys.PeerAddress, targetID)
+			closestNodes, err := dht.FindNodeDirectToSystem(sys, targetID)
 			if err != nil {
 				responses[idx].err = err
 				return

--- a/dht_maintenance.go
+++ b/dht_maintenance.go
@@ -68,13 +68,11 @@ func (dht *DHT) checkPeerLiveness() {
 		}
 
 		// Ping and announce in one go
-		if _, err := dht.Ping(sys.PeerAddress); err != nil {
-			dht.routingTable.MarkFailed(sys.ID)
+		if err := dht.PingNode(sys); err != nil {
 			dead++
 		} else {
-			dht.routingTable.MarkVerified(sys.ID)
 			// Also announce ourselves so they know we're alive
-			dht.AnnounceTo(sys.PeerAddress)
+			dht.AnnounceToSystem(sys)
 			alive++
 		}
 	}
@@ -106,7 +104,7 @@ func (dht *DHT) announceToNetwork() {
 			continue
 		}
 
-		if err := dht.AnnounceTo(sys.PeerAddress); err != nil {
+		if err := dht.AnnounceToSystem(sys); err != nil {
 			log.Printf("  Failed to announce to %s: %v", sys.Name, err)
 			dht.routingTable.MarkFailed(sys.ID)
 		} else {


### PR DESCRIPTION
So, when I had an 11th hour wild idea to double down on the security on the messages right before release, I rushed too much. In my haste I left a flaw: the `toSystemID` is more often than not nil, result in a uuid of all zeroes. This is then part of the signed and secured message and logged be the receiver.

This means that i need to change how messages are contructed and signed, because I forgot to change how they were constructed before adding the signing. Now, a lot of things that SHOULD have depended on that field were fixed by adding a backwards compatible change of a new field. that did double duty as its new p urpose and also solving for this problem

but this left a hole: i still need an unbroken chain of signed messages with signed fields, which this new field was not... for secure tracking of credit earnings if we ever want to let people send and receive credits in the future.

I don't even know if we ever will, but i dont want to fix this problem with a forced change when whe have 1,000 node and all those credits "lost" behind the change wall.

So here is a not quite major but big protocol changing update that will fix this going forward. If you dont update, well, things will work just fine but credits you earn before the update wont be exchangeable... IF we ever even allow them to be at all. That's really the only pain and that feature is so far off in the future, if it ever even is, hopefully we'll be good with most adopters coming after this release.

maybe? lol
