### PR TITLE
Fixed some Kademlia routing issues

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -193,8 +193,8 @@ func (dht *DHT) bootstrapFromPeer(address string) error {
 
 	log.Printf("  Connected to %s (%s)", sys.Name, sys.ID.String()[:8])
 
-	// Add to routing table
-	dht.routingTable.Update(sys)
+	// Add to routing table (proper Kademlia LRS-ping if bucket full)
+	dht.updateRoutingTable(sys)
 	dht.routingTable.MarkVerified(sys.ID)
 
 	// Query for nodes close to us - now we know who we're talking to
@@ -204,7 +204,7 @@ func (dht *DHT) bootstrapFromPeer(address string) error {
 	}
 
 	for _, node := range closest {
-		dht.routingTable.Update(node)
+		dht.updateRoutingTable(node)
 	}
 
 	log.Printf("  Learned about %d nodes", len(closest))
@@ -289,7 +289,7 @@ func (dht *DHT) bootstrapFromSeed(seedAddr string) error {
 			continue
 		}
 
-		dht.routingTable.Update(fullSys)
+		dht.updateRoutingTable(fullSys)
 		dht.routingTable.MarkVerified(fullSys.ID)
 		connected++
 		log.Printf("    Connected to %s", fullSys.Name)
@@ -298,7 +298,7 @@ func (dht *DHT) bootstrapFromSeed(seedAddr string) error {
 		closest, err := dht.FindNodeDirectToSystem(fullSys, dht.localSystem.ID)
 		if err == nil {
 			for _, node := range closest {
-				dht.routingTable.Update(node)
+				dht.updateRoutingTable(node)
 			}
 		}
 

--- a/dht_lookup.go
+++ b/dht_lookup.go
@@ -109,8 +109,8 @@ func (dht *DHT) FindNode(targetID uuid.UUID) *LookupResult {
 					allNodes[sys.ID] = sys
 					newNodesFound = true
 
-					// Update routing table and cache
-					dht.routingTable.Update(sys)
+					// Update routing table and cache (proper Kademlia LRS-ping if bucket full)
+					dht.updateRoutingTable(sys)
 				}
 			}
 		}


### PR DESCRIPTION
I was having issues with far flung nodes.. turns out, I only half baked my kademlia implementation.. whoops.

- Add replacement cache to each k-bucket for candidates waiting for slots
- Implement least-recently-seen (LRS) ping check 
- Live nodes are never removed
- Promote from replacement cache when bucket nodes die
- Add LastGossipHeard tracking for smarter cache pruning because I am STILL chasing cache issues
- Ensure all message exchanges (PING, FIND_NODE, ANNOUNCE) mark sender as verified
- Update all routing table callers to use new updates

This fixes the issue where old nodes fail to learn about new peers because their buckets were full and new nodes were simply rejected.